### PR TITLE
This and that

### DIFF
--- a/cradle/application.gradle
+++ b/cradle/application.gradle
@@ -1,7 +1,7 @@
 dependencies {
     // DI/IoC is a sane thing to do; we like Guice as our flavor
     compile group:'com.google.inject', name:'guice', version:'4.0'
-	
+
 	// Logback is our selection for production logging
-    compile group:'ch.qos.logback', name:'logback-classic', version:'1.0.13'
+    compile group:'ch.qos.logback', name:'logback-classic', version:'1.1.3'
 }

--- a/cradle/base.gradle
+++ b/cradle/base.gradle
@@ -2,6 +2,16 @@ repositories {
     mavenLocal()
 }
 
+// enable Markdown in javadoc
+configurations {
+    markdownDoclet
+}
+javadoc.options {
+    docletpath = configurations.markdownDoclet.files.asType(List) // gradle should relly make this simpler
+    doclet = "ch.raffael.doclets.pegdown.PegdownDoclet"
+    addStringOption("parse-timeout", "10")
+}
+
 dependencies {
     // slf4j
     compile group:'org.slf4j', name:'slf4j-api', version:'1.7.9'
@@ -14,6 +24,8 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
     testCompile group: 'org.hamcrest', name: 'hamcrest-junit', version: '2.0.0.0'
+
+    markdownDoclet 'ch.raffael.pegdown-doclet:pegdown-doclet:1.1.1'
 }
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'

--- a/cradle/base.gradle
+++ b/cradle/base.gradle
@@ -14,10 +14,10 @@ javadoc.options {
 
 dependencies {
     // slf4j
-    compile group:'org.slf4j', name:'slf4j-api', version:'1.7.9'
+    compile group:'org.slf4j', name:'slf4j-api', version:'1.7.13'
 
     // better collections and other assorted utils
-    compile group: 'com.google.guava', name:'guava', version:'18.0'
+    compile group: 'com.google.guava', name:'guava', version:'19.0'
 
     // these are the EXACT dependencies one has to use when using the JUnit+Mockito combo to avoid Hamcrest
     // compilation/runtime problems

--- a/cradle/library.gradle
+++ b/cradle/library.gradle
@@ -2,5 +2,5 @@ apply from: file("${rootProject.projectDir}/cradle/base.gradle")
 
 dependencies {
     // logback for logging during testing
-    testCompile group:'ch.qos.logback', name:'logback-classic', version:'1.0.13'
+    testCompile group:'ch.qos.logback', name:'logback-classic', version:'1.1.3'
 }

--- a/cradle/publishing.gradle
+++ b/cradle/publishing.gradle
@@ -16,6 +16,7 @@ artifacts {
 }
 
 signing {
+    required { gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
 

--- a/cradle/webserver.gradle
+++ b/cradle/webserver.gradle
@@ -2,5 +2,5 @@ apply from: file("${rootProject.projectDir}/cradle/application.gradle")
 
 dependencies {
     // Actual web server
-    compile group:'io.undertow', name:'undertow-core', version:'1.1.1.Final'
+    compile group:'io.undertow', name:'undertow-core', version:'1.3.11.Final'
 }


### PR DESCRIPTION
 - Enable using markdown for javadocs to make stylized documentation easier to maintain
 - Sign release JARs only for actual remote publishing
 - update dependency versions