### PR TITLE
include sourceSet delombokifiers

### DIFF
--- a/cradle/base.gradle
+++ b/cradle/base.gradle
@@ -8,6 +8,7 @@ repositories {
 
 configurations {
     markdownDoclet
+    provided
 }
 
 dependencies {
@@ -24,13 +25,45 @@ dependencies {
     testCompile group: 'org.hamcrest', name: 'hamcrest-junit', version: '2.0.0.0'
 
     markdownDoclet "ch.raffael.pegdown-doclet:pegdown-doclet:1.1.1"
-}
 
-// set all sources to UTF-8 for proper unicode support
-[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+    provided "org.projectlombok:lombok:1.16.6"
+}
 
 javadoc.options {
     docletpath = configurations.markdownDoclet.files.asType(List) // gradle should relly make this simpler
     doclet = "ch.raffael.doclets.pegdown.PegdownDoclet"
     addStringOption("parse-timeout", "10")
+}
+// set all sources to UTF-8 for proper unicode support
+[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+
+// advanced delombok for all defined sourceSets, originally based on http://stackoverflow.com/q/24997441/44523
+sourceSets.all {
+    Task dependent = tasks.findByName("compile${name.capitalize()}Java")
+    if (!dependent) dependent = compileJava
+
+    // need to redefine name variable as otherwise Groovy gets a bit too excited and uses actual task name instead
+    def sourceSetName = name
+    def taskName = 'delombok' + name.capitalize()
+    tasks.create(taskName) {
+        description "Delomboks the ${name} source code tree"
+
+        doLast {
+            def sumTree = files( configurations.provided + compileClasspath )
+
+            ant.taskdef(
+                name: taskName,
+                classname: 'lombok.delombok.ant.Tasks$Delombok',
+                classpath: sumTree.asPath
+            )
+            ant."$taskName"(
+                verbose: true,
+                encoding: 'UTF-8',
+                from: "src/${sourceSetName}/java",
+                to: "build/src-delomboked/${sourceSetName}",
+                classpath: sumTree.asPath
+            )
+        }
+    }
+    dependent.dependsOn taskName
 }


### PR DESCRIPTION
Delomboks every Java related sourceSet available in build configuration.

Curiously the `provided` configuration definition works just fine and in intended way if actual project `build.gradle` uses [Nebula Extra Configurations plugin](https://github.com/nebula-plugins/gradle-extra-configurations-plugin).